### PR TITLE
Set DBLP_BASE_URL to dblp.org

### DIFF
--- a/bibtex_dblp/config.py
+++ b/bibtex_dblp/config.py
@@ -3,7 +3,7 @@ Configuration.
 """
 
 # DBLP URLs
-DBLP_BASE_URL = 'https://dblp.uni-trier.de/'
+DBLP_BASE_URL = 'https://dblp.org/'
 DBLP_PUBLICATION_SEARCH_URL = DBLP_BASE_URL + 'search/publ/api'
 DBLP_PUBLICATION_BIBTEX = DBLP_BASE_URL + 'rec/{bib_format}/{key}.bib'
 


### PR DESCRIPTION
The old `dblp.uni-trier.de` is not responding very well (at least right now).
As mentioned on [this](https://dblp.org/faq/How+to+use+the+dblp+search+API.html) page it should just be `dblp.org`.