### PR TITLE
Manually replace escaped characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ The user can select the correct entry from a list of possible matches and the bi
 Bibtex entries which already have a DBLP id are left unchanged.
 
 
+### Modifying bibliography
+The script `bin/modify_bibtex.py` allows apply some modifications on the bibtex file:
+- `--no-escape` removes the escape characters in front of underscores for fields `url` and `doi`. So `\_` becomes `_`. Note that this requires the packages such as `hyperref` in LaTeX to properly compile.
+- `--no-timestamp`, `--no-biburl` and `--no-bibsource` can be added to remove the corresponding fields `timestamp`, `biburl` and `bibsource`, respectively, from the bibtex file.
+
 ## Supported DBLP formats
 The following bibtex formats from DBLP are currently supported:
 - `condensed`: Condensed format where e.g. journals and conferences are abbreviated. Default value.

--- a/bibtex_dblp/database.py
+++ b/bibtex_dblp/database.py
@@ -45,7 +45,7 @@ def convert_dblp_entries(session, bib, bib_format=dblp_api.BibFormat.condensed):
     :param session: DBLP session.
     :param bib: Bibliography in pybtex format.
     :param bib_format: Bibtex format of DBLP.
-    :return: converted bibliography, number of changed entries
+    :return: Converted bibliography, number of changed entries
     """
     logging.debug("Convert to format '{}'".format(bib_format))
     no_changes = 0
@@ -82,6 +82,33 @@ def convert_dblp_entries(session, bib, bib_format=dblp_api.BibFormat.condensed):
             logging.debug("Set new entry for '{}'".format(entry_str))
             no_changes += 1
     return bib, no_changes
+
+
+def modify_entries(bib, remove_escapes=False, remove_timestamp=False, remove_biburl=False, remove_bibsource=False):
+    """
+    Modify bibtex entries.
+    :param bib: Bibliography in pybtex format.
+    :param remove_escapes: Whether to remove escape characters before underscore in URLs.
+    :param remove_timestamp: Whether to remove field 'timestamp'.
+    :param remove_biburl: Whether to remove field 'biburl'.
+    :param remove_bibsource: Whether to remove field 'bibsource'.
+    :return: Modified bibliography.
+    """
+    if not remove_escapes and not remove_timestamp and not remove_biburl and not remove_bibsource:
+        return bib
+
+    for entry_str, entry in bib.entries.items():
+        if remove_escapes and "url" in entry.fields:
+            entry.fields["url"] = entry.fields["url"].replace("\\_", "_")
+        if remove_escapes and "doi" in entry.fields:
+            entry.fields["doi"] = entry.fields["doi"].replace("\\_", "_")
+        if remove_timestamp and "timestamp" in entry.fields:
+            del entry.fields["timestamp"]
+        if remove_biburl and "biburl" in entry.fields:
+            del entry.fields["biburl"]
+        if remove_bibsource and "bibsource" in entry.fields:
+            del entry.fields["bibsource"]
+    return bib
 
 
 def search(bib, search_string):

--- a/bibtex_dblp/database.py
+++ b/bibtex_dblp/database.py
@@ -1,6 +1,6 @@
 import logging
-
 import pybtex.database
+import re
 
 import bibtex_dblp.dblp_api as dblp_api
 import bibtex_dblp.search
@@ -22,6 +22,12 @@ def write_to_file(bib, outfile):
     :param outfile: Path of output file.
     """
     bib.to_file(outfile, bib_format="bibtex")
+
+    # Perform some custom changes
+    content = outfile.read_text(encoding="utf-8")
+    # Replace multiple escape characters \\ before by a single one \
+    content = re.sub(r"\\{2,}", r"\\", content)
+    outfile.write_text(content, encoding="utf-8")
 
 
 def parse_bibtex(bibtex):

--- a/bin/convert_dblp.py
+++ b/bin/convert_dblp.py
@@ -5,6 +5,7 @@ Convert DBLP entries in a given bibliography according to the specific DBLP form
 
 import argparse
 import logging
+from pathlib import Path
 
 import bibtex_dblp.database
 from bibtex_dblp.dblp_api import BibFormat, DblpSession
@@ -13,8 +14,8 @@ from bibtex_dblp.dblp_api import BibFormat, DblpSession
 def main():
     parser = argparse.ArgumentParser(description="Convert DBLP entries to specific format (condensed, standard, crossref).")
 
-    parser.add_argument("infile", help="Input bibtex file", type=str)
-    parser.add_argument("--out", "-o", help="Output bibtex file. If no output file is given, the input file will be overwritten.", type=str, default=None)
+    parser.add_argument("infile", help="Input bibtex file", type=Path)
+    parser.add_argument("--out", "-o", help="Output bibtex file. If no output file is given, the input file will be overwritten.", type=Path, default=None)
     parser.add_argument("--format", "-f", help="DBLP format type to convert into", type=BibFormat, choices=list(BibFormat), default=BibFormat.condensed)
     parser.add_argument("--sleep-time", "-t", help="Sleep time (in seconds) between requests. Can prevent errors with too many requests)", type=int, default=5)
 

--- a/bin/import_dblp.py
+++ b/bin/import_dblp.py
@@ -5,8 +5,8 @@ Import entry from DBLP according to given search input.
 
 import argparse
 import logging
-
 import pyperclip
+from pathlib import Path
 
 import bibtex_dblp.database
 import bibtex_dblp.dblp_api
@@ -24,7 +24,7 @@ def main():
         "--bib",
         "-b",
         help="Bibtex file where the imported entry will be appended. If no bibtex file is given, the bibtex is printed to the CLI.",
-        type=str,
+        type=Path,
         default=None,
     )
     parser.add_argument("--format", "-f", help="DBLP format type to convert into.", type=BibFormat, choices=list(BibFormat), default=BibFormat.condensed)

--- a/bin/modify_bibtex.py
+++ b/bin/modify_bibtex.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+"""
+Apply modifications on the bibtex entries.
+"""
+
+import argparse
+import logging
+from pathlib import Path
+import re
+
+import bibtex_dblp.database
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Apply modifications on the bibtex file.")
+
+    parser.add_argument("infile", help="Input bibtex file", type=Path)
+    parser.add_argument("--out", "-o", help="Output bibtex file. If no output file is given, the input file will be overwritten.", type=Path, default=None)
+    parser.add_argument("--no-escape", help="Disable escaping of underscores in URLs", action="store_true")
+    parser.add_argument("--no-timestamp", help="Remove timestamp field (if present)", action="store_true")
+    parser.add_argument("--no-biburl", help="Remove biburl field (if present)", action="store_true")
+    parser.add_argument("--no-bibsource", help="Remove bibsource field (if present)", action="store_true")
+
+    parser.add_argument("--verbose", "-v", help="print more output", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.DEBUG if args.verbose else logging.INFO)
+
+    outfile = args.infile if args.out is None else args.out
+
+    bib = bibtex_dblp.database.load_from_file(args.infile)
+    # Apply modifications
+    bib = bibtex_dblp.database.modify_entries(
+        bib, remove_escapes=args.no_escapes, remove_timestamp=args.no_timestamp, remove_biburl=args.no_biburl, remove_bibsource=args.no_bibsource
+    )
+    bibtex_dblp.database.write_to_file(bib, outfile)
+    if args.no_escape:
+        # Need to manually remove escape characters which are automatically added again by pybtex to ensure LaTeX compatibility
+        out_lines = []
+        for line in outfile.read_text(encoding="utf-8").splitlines(keepends=True):
+            # Detect start of a doi or url field
+            if re.match(r"\s*(doi|url)\s*=", line, flags=re.IGNORECASE):
+                # Remove backslash
+                line = re.sub(r"\\_", r"_", line)
+            out_lines.append(line)
+        outfile.write_text("".join(out_lines), encoding="utf-8")
+
+    logging.info("Written to {}".format(outfile))
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/update_from_dblp.py
+++ b/bin/update_from_dblp.py
@@ -6,7 +6,6 @@ Import entry from DBLP according to given search input.
 import argparse
 import logging
 import requests
-import time
 from copy import deepcopy
 
 import bibtex_dblp.database

--- a/bin/update_from_dblp.py
+++ b/bin/update_from_dblp.py
@@ -7,6 +7,7 @@ import argparse
 import logging
 import requests
 from copy import deepcopy
+from pathlib import Path
 
 import bibtex_dblp.database
 import bibtex_dblp.dblp_api
@@ -42,8 +43,8 @@ def search_entry(session, search_string, max_search_results, include_arxiv):
 def main():
     parser = argparse.ArgumentParser(description="Update entries in bibliography via DBLP.")
 
-    parser.add_argument("infile", help="Input bibtex file", type=str)
-    parser.add_argument("--out", "-o", help="Output bibtex file. If no output file is given, the input file will be overwritten.", type=str, default=None)
+    parser.add_argument("infile", help="Input bibtex file", type=Path)
+    parser.add_argument("--out", "-o", help="Output bibtex file. If no output file is given, the input file will be overwritten.", type=Path, default=None)
     parser.add_argument("--format", "-f", help="DBLP format type to convert into", type=BibFormat, choices=list(BibFormat), default=BibFormat.condensed)
     parser.add_argument("--max-results", help="Maximal number of search results to display.", type=int, default=30)
     parser.add_argument("--disable-auto", help="Disable automatic selection of publications.", action="store_true")

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -1,0 +1,33 @@
+from conftest import bib_path
+
+from difflib import unified_diff
+
+import bibtex_dblp.database
+
+
+def test_import_export(tmp_path):
+    """
+    Check that importing and exporting multiple times yields the same results
+    """
+    # Import and export
+    bib = bibtex_dblp.database.load_from_file(bib_path("ley.bib"))
+    tmp_file1 = tmp_path / "export1.bib"
+    bibtex_dblp.database.write_to_file(bib, tmp_file1)
+
+    # Compare files
+    with open(bib_path("ley.bib")) as f1:
+        with open(tmp_file1) as f2:
+            diff = list(unified_diff(f1.readlines(), f2.readlines()))
+    # The files differ due to different formatting
+    # assert not diff, "Files differ:\n{}".format("".join(diff))
+
+    # Import and export
+    bib = bibtex_dblp.database.load_from_file(tmp_file1)
+    tmp_file2 = tmp_path / "export2.bib"
+    bibtex_dblp.database.write_to_file(bib, tmp_file2)
+
+    # Compare files
+    with open(tmp_file1) as f1:
+        with open(tmp_file2) as f2:
+            diff = list(unified_diff(f1.readlines(), f2.readlines()))
+    assert not diff, "Files differ:\n{}".format("".join(diff))

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -31,3 +31,25 @@ def test_import_export(tmp_path):
         with open(tmp_file2) as f2:
             diff = list(unified_diff(f1.readlines(), f2.readlines()))
     assert not diff, "Files differ:\n{}".format("".join(diff))
+
+
+def test_modify_entries():
+    def count_entries(_bib):
+        num_escapes = num_timestamp = num_biburl = num_bibsource = 0
+        for entry_str, entry in _bib.entries.items():
+            if "url" in entry.fields and "\\_" in entry.fields["url"]:
+                num_escapes += 1
+            if "doi" in entry.fields and "\\_" in entry.fields["doi"]:
+                num_escapes += 1
+            if "timestamp" in entry.fields:
+                num_timestamp += 1
+            if "biburl" in entry.fields:
+                num_biburl += 1
+            if "bibsource" in entry.fields:
+                num_bibsource += 1
+        return num_escapes, num_timestamp, num_biburl, num_bibsource
+
+    bib = bibtex_dblp.database.load_from_file(bib_path("ley.bib"))
+    assert count_entries(bib) == (2, 9, 9, 9)
+    bib = bibtex_dblp.database.modify_entries(bib, remove_escapes=True, remove_timestamp=True, remove_biburl=True, remove_bibsource=True)
+    assert count_entries(bib) == (0, 0, 0, 0)


### PR DESCRIPTION
Fixes #21

Ideally, escaped characters should be properly handled by pybtex, see [this issue](https://codeberg.org/pybtex/pybtex/issues/24). Until this is fixed, this PR manually replaces `\\` by `\`.

Adds a new script `modify_bibtex.py` which allows to apply some modifications on the bibtex file, for instance removing some fields. The argument `--no-escape` replaces all `\_` in URLs by `_`.